### PR TITLE
Fix foreground

### DIFF
--- a/autoload/minimap.vim
+++ b/autoload/minimap.vim
@@ -85,6 +85,7 @@ function! minimap#_on_open()
   if exists('g:minimap_ack')
     let expr = printf(':call minimap#_ack_open("%s")<CR>', v:servername)
     call remote_send(g:minimap_ack, expr)
+    call remote_foreground(g:minimap_ack)
     unlet g:minimap_ack
   endif
 endfunction
@@ -212,7 +213,6 @@ function! minimap#_lazysync_do()
 endfunction
 
 function! minimap#_ack_open(id)
-  call foreground()
   call minimap#_send_and_enter_minimap_mode(a:id)
 endfunction
 


### PR DESCRIPTION
`:help foreground()` によると Windows ではちゃんと動かないとある。現に私の所ではフォアグラウンドにならない。
